### PR TITLE
Update mysql official image from 5.7.25 to 5.7.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-MYSQL57_VERSION := mysql:5.7.25
+MYSQL57_VERSION := mysql:5.7.26
 BINLOG_FORMATS := row mixed statement
 
 .PHONY: default
@@ -17,7 +17,7 @@ test:
 	docker-compose exec mysqld sh -c 'for i in $$(seq 60);do mysql -e "select version()" && exit; sleep 1;done'
 	docker-compose exec mysqld sh -c 'mysql --local-infile=1 </work/error.sql;true'
 	@echo '注意:'
-	@echo '"ERROR 1048 (23000) at line 17: Column '\''addr'\'' cannot be null" と出るようならばバグが存在します'
+	@echo '"ERROR 1048 (23000) at line XX: Column '\''addr'\'' cannot be null" と出るようならばバグが存在します'
 	docker-compose down
 
 .PHONY: test-rep
@@ -44,25 +44,25 @@ official-5.7: ## docker official の MySQL 5.7 イメージでテスト
 	@make IMAGE=$(MYSQL57_VERSION) test
 
 official-8.0: ## docker official の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql:8.0.14 test
+	@make IMAGE=mysql:8.0.16 test
 
 oracle-5.7: ## Oracle の MySQL 5.7 イメージでテスト
 	@make IMAGE=mysql/mysql-server:5.7.25 test
 
 oracle-8.0: ## Oracle の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql/mysql-server:8.0.14 test
+	@make IMAGE=mysql/mysql-server:8.0.15 test
 
 mariadb-10.1: ## docker official の MariaDB 10.1 イメージでテスト
-	@make IMAGE=mariadb:10.1.37 test
+	@make IMAGE=mariadb:10.1.38 test
 
 mariadb-10.2: ## docker official の MariaDB 10.2 イメージでテスト
-	@make IMAGE=mariadb:10.2.21 test
+	@make IMAGE=mariadb:10.2.23 test
 
 mariadb-10.3: ## docker official の MariaDB 10.3 イメージでテスト
-	@make IMAGE=mariadb:10.3.12 test
+	@make IMAGE=mariadb:10.3.14 test
 
 mariadb-10.4: ## docker official の MariaDB 10.4 イメージでテスト
-	@make IMAGE=mariadb:10.4.1 test
+	@make IMAGE=mariadb:10.4.4 test
 
 .PHONY: all-rep
 define rep_target_template


### PR DESCRIPTION
- mysql 5.7.25 -> 5.7.26
- mysql 8.0.14 -> 8.0.16
- mysql/mysql-server 8.0.14 -> 8.0.15
- mariadb 10.1.37 -> 10.1.38
- mariadb 10.2.21 -> 10.2.23
- mariadb 10.3.12 -> 10.3.14
- mariadb 10.4.1  -> 10.4.4