### PR TITLE
Update mysql official image from 5.7.26 to 5.7.27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-MYSQL57_VERSION := mysql:5.7.26
+MYSQL57_VERSION := mysql:5.7.27
 BINLOG_FORMATS := row mixed statement
 
 .PHONY: default
@@ -44,25 +44,25 @@ official-5.7: ## docker official の MySQL 5.7 イメージでテスト
 	@make IMAGE=$(MYSQL57_VERSION) test
 
 official-8.0: ## docker official の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql:8.0.16 test
+	@make IMAGE=mysql:8.0.17 test
 
 oracle-5.7: ## Oracle の MySQL 5.7 イメージでテスト
-	@make IMAGE=mysql/mysql-server:5.7.25 test
+	@make IMAGE=mysql/mysql-server:5.7.27 test
 
 oracle-8.0: ## Oracle の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql/mysql-server:8.0.15 test
+	@make IMAGE=mysql/mysql-server:8.0.17 test
 
 mariadb-10.1: ## docker official の MariaDB 10.1 イメージでテスト
-	@make IMAGE=mariadb:10.1.38 test
+	@make IMAGE=mariadb:10.1.40 test
 
 mariadb-10.2: ## docker official の MariaDB 10.2 イメージでテスト
-	@make IMAGE=mariadb:10.2.23 test
+	@make IMAGE=mariadb:10.2.25 test
 
 mariadb-10.3: ## docker official の MariaDB 10.3 イメージでテスト
-	@make IMAGE=mariadb:10.3.14 test
+	@make IMAGE=mariadb:10.3.16 test
 
 mariadb-10.4: ## docker official の MariaDB 10.4 イメージでテスト
-	@make IMAGE=mariadb:10.4.4 test
+	@make IMAGE=mariadb:10.4.6 test
 
 .PHONY: all-rep
 define rep_target_template


### PR DESCRIPTION
- mysql 5.7.26 -> 5.7.27
- mysql 8.0.16 -> 8.0.17
- mysql/mysql-server 5.7.25 -> 5.7.27
- mysql/mysql-server 8.0.15 -> 8.0.17
- mariadb 10.1.38 -> 10.1.40
- mariadb 10.2.23 -> 10.2.25
- mariadb 10.3.14 -> 10.3.16
- mariadb 10.4.4  -> 10.4.6