### PR TITLE
Update mysql official image from 5.7.29 to 5.7.30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-MYSQL57_VERSION := mysql:5.7.29
+MYSQL57_VERSION := mysql:5.7.30
 BINLOG_FORMATS := row mixed statement
 
 .PHONY: default
@@ -37,32 +37,35 @@ test-rep:
 	docker-compose down
 
 .PHONY: all
-all: official-5.7 official-8.0 oracle-5.7 oracle-8.0 mariadb-10.1 mariadb-10.2 mariadb-10.3 mariadb-10.4 ## すべてのテストを実施
+all: official-5.7 official-8.0 oracle-5.7 oracle-8.0 mariadb-10.1 mariadb-10.2 mariadb-10.3 mariadb-10.4 mariadb-10.5 ## すべてのテストを実施
 
-.PHONY: official-5.7 official-8.0 oracle-5.7 oracle-8.0 mariadb-10.1 mariadb-10.2 mariadb-10.3 mariadb-10.4
+.PHONY: official-5.7 official-8.0 oracle-5.7 oracle-8.0 mariadb-10.1 mariadb-10.2 mariadb-10.3 mariadb-10.4 mariadb-10.5
 official-5.7: ## docker official の MySQL 5.7 イメージでテスト
 	@make IMAGE=$(MYSQL57_VERSION) test
 
 official-8.0: ## docker official の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql:8.0.19 test
+	@make IMAGE=mysql:8.0.20 test
 
 oracle-5.7: ## Oracle の MySQL 5.7 イメージでテスト
-	@make IMAGE=mysql/mysql-server:5.7.29 test
+	@make IMAGE=mysql/mysql-server:5.7.30 test
 
 oracle-8.0: ## Oracle の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql/mysql-server:8.0.19 test
+	@make IMAGE=mysql/mysql-server:8.0.20 test
 
 mariadb-10.1: ## docker official の MariaDB 10.1 イメージでテスト
-	@make IMAGE=mariadb:10.1.43 test
+	@make IMAGE=mariadb:10.1.44 test
 
 mariadb-10.2: ## docker official の MariaDB 10.2 イメージでテスト
-	@make IMAGE=mariadb:10.2.30 test
+	@make IMAGE=mariadb:10.2.31 test
 
 mariadb-10.3: ## docker official の MariaDB 10.3 イメージでテスト
-	@make IMAGE=mariadb:10.3.21 test
+	@make IMAGE=mariadb:10.3.22 test
 
 mariadb-10.4: ## docker official の MariaDB 10.4 イメージでテスト
-	@make IMAGE=mariadb:10.4.11 test
+	@make IMAGE=mariadb:10.4.12 test
+
+mariadb-10.5: ## docker official の MariaDB 10.5 イメージでテスト
+	@make IMAGE=mariadb:10.5.2 test
 
 .PHONY: all-rep
 define rep_target_template


### PR DESCRIPTION
- mysql 5.7.29 -> 5.7.30
- mysql 8.0.19 -> 8.0.20
- mysql/mysql-server 5.7.29 -> 5.7.30
- mysql/mysql-server 8.0.19 -> 8.0.20
- mariadb 10.1.43 -> 10.1.44
- mariadb 10.2.29 -> 10.2.31
- mariadb 10.3.19 -> 10.3.22
- mariadb 10.4.11 -> 10.4.12
- Add mariadb 10.5.2