### PR TITLE
Update mysql official image from 5.7.31 to 5.7.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-MYSQL57_VERSION := mysql:5.7.31
+MYSQL57_VERSION := mysql:5.7.32
 BINLOG_FORMATS := row mixed statement
 RESULT_FILE := result.txt
 
@@ -50,28 +50,28 @@ official-5.7: ## docker official の MySQL 5.7 イメージでテスト
 	@make IMAGE=$(MYSQL57_VERSION) test
 
 official-8.0: ## docker official の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql:8.0.21 test
+	@make IMAGE=mysql:8.0.22 test
 
 oracle-5.7: ## Oracle の MySQL 5.7 イメージでテスト
-	@make IMAGE=mysql/mysql-server:5.7.31 test
+	@make IMAGE=mysql/mysql-server:5.7.32 test
 
 oracle-8.0: ## Oracle の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql/mysql-server:8.0.21 test
+	@make IMAGE=mysql/mysql-server:8.0.22 test
 
 mariadb-10.1: ## docker official の MariaDB 10.1 イメージでテスト
-	@make IMAGE=mariadb:10.1.45 test
+	@make IMAGE=mariadb:10.1.47 test
 
 mariadb-10.2: ## docker official の MariaDB 10.2 イメージでテスト
-	@make IMAGE=mariadb:10.2.32 test
+	@make IMAGE=mariadb:10.2.34 test
 
 mariadb-10.3: ## docker official の MariaDB 10.3 イメージでテスト
-	@make IMAGE=mariadb:10.3.23 test
+	@make IMAGE=mariadb:10.3.25 test
 
 mariadb-10.4: ## docker official の MariaDB 10.4 イメージでテスト
-	@make IMAGE=mariadb:10.4.13 test
+	@make IMAGE=mariadb:10.4.15 test
 
 mariadb-10.5: ## docker official の MariaDB 10.5 イメージでテスト
-	@make IMAGE=mariadb:10.5.4 test
+	@make IMAGE=mariadb:10.5.6 test
 
 .PHONY: all-rep
 define rep_target_template


### PR DESCRIPTION
- mysql 5.7.31 -> 5.7.32
- mysql 8.0.21 -> 8.0.22
- mysql/mysql-server 5.7.31 -> 5.7.32
- mysql/mysql-server 8.0.21 -> 8.0.22
- mariadb 10.1.45 -> 10.1.47
- mariadb 10.2.32 -> 10.2.34
- mariadb 10.3.23 -> 10.3.25
- mariadb 10.4.13 -> 10.4.15
- mariadb 10.5.4  -> 10.5.6