### PR TITLE
Update mysql official image from 5.7.34 to 5.7.35

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ test-rep:
 	docker-compose exec slave sh -c 'mysql -sNe "show variables" | grep -e gtid_mode -e sql_mode -e binlog_format'
 	docker-compose exec master sh -c 'mysql --local-infile=1 </work/rep-error.sql;true'
 	docker-compose exec master mysql bar -e 'UPDATE ip SET addr="192.168.0.1" WHERE id = 1'
+	sleep 3
 	docker-compose exec slave mysql bar -e 'select * from ip'
 	docker-compose exec slave sh -c 'mysql -e "show slave status\G" | grep -e "_Running:" -e "Seconds_Behind_Master"'
 	@echo '*******************************************************************************************************************'


### PR DESCRIPTION
- mysql 5.7.34 -> 5.7.35
- mysql 8.0.24 -> 8.0.26
- mysql/mysql-server 5.7.34 -> 5.7.35
- mysql/mysql-server 8.0.24 -> 8.0.26
- mariadb 10.3.28 -> 10.3.30
- mariadb 10.4.18 -> 10.4.20
- mariadb 10.5.9  -> 10.5.11
- Add mariadb 10.6
- Remove mariadb 10.1/10.2