### PR TITLE
Update mysql official image from 5.7.39 to 5.7.40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-MYSQL57_VERSION := mysql:5.7.39
+MYSQL57_VERSION := mysql:5.7.40
 BINLOG_FORMATS := row mixed statement
 RESULT_FILE := result.txt
 
@@ -51,19 +51,19 @@ official-5.7: ## docker official の MySQL 5.7 イメージでテスト
 	@make IMAGE=$(MYSQL57_VERSION) test
 
 official-8.0: ## docker official の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql:8.0.30 test
+	@make IMAGE=mysql:8.0.31 test
 
 oracle-5.7: ## Oracle の MySQL 5.7 イメージでテスト
-	@make IMAGE=mysql/mysql-server:5.7.39 test
+	@make IMAGE=mysql/mysql-server:5.7.40 test
 
 oracle-8.0: ## Oracle の MySQL 8.0 イメージでテスト
-	@make IMAGE=mysql/mysql-server:8.0.30 test
+	@make IMAGE=mysql/mysql-server:8.0.31 test
 
 mariadb-10.6: ## docker official の MariaDB 10.6 イメージでテスト
-	@make IMAGE=mariadb:10.6.8 test
+	@make IMAGE=mariadb:10.6.10 test
 
 mariadb-10.7: ## docker official の MariaDB 10.7 イメージでテスト
-	@make IMAGE=mariadb:10.7.4 test
+	@make IMAGE=mariadb:10.7.6 test
 
 .PHONY: all-rep
 define rep_target_template


### PR DESCRIPTION
- mysql 5.7.39 -> 5.7.40
- mysql 8.0.30 -> 8.0.31
- mysql/mysql-server 5.7.39 -> 5.7.40
- mysql/mysql-server 8.0.30 -> 8.0.31
- mariadb 10.6.8 -> 10.6.10
- mariadb 10.7.4 -> 10.7.6